### PR TITLE
add support for external shuffle service and dynamic allocation

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/kubernetes/KubernetesExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/kubernetes/KubernetesExternalShuffleClient.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.kubernetes;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.spark.network.client.RpcResponseCallback;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.sasl.SecretKeyHolder;
+import org.apache.spark.network.shuffle.ExternalShuffleClient;
+import org.apache.spark.network.shuffle.protocol.mesos.RegisterDriver;
+import org.apache.spark.network.shuffle.protocol.mesos.ShuffleServiceHeartbeat;
+import org.apache.spark.network.util.TransportConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A client for talking to the external shuffle service in Kubernetes cluster mode.
+ *
+ * This is used by the each Spark executor to register with a corresponding external
+ * shuffle service on the cluster. The purpose is for cleaning up shuffle files
+ * reliably if the application exits unexpectedly.
+ */
+public class KubernetesExternalShuffleClient extends ExternalShuffleClient {
+    private static final Logger logger = LoggerFactory
+            .getLogger(KubernetesExternalShuffleClient.class);
+
+    private final ScheduledExecutorService heartbeaterThread =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder()
+                            .setDaemon(true)
+                            .setNameFormat("kubernetes-external-shuffle-client-heartbeater")
+                            .build());
+
+    /**
+     * Creates a Kubernetes external shuffle client that wraps the {@link ExternalShuffleClient}.
+     * Please refer to docs on {@link ExternalShuffleClient} for more information.
+     */
+    public KubernetesExternalShuffleClient(
+            TransportConf conf,
+            SecretKeyHolder secretKeyHolder,
+            boolean saslEnabled,
+            long registrationTimeoutMs) {
+        super(conf, secretKeyHolder, saslEnabled, registrationTimeoutMs);
+    }
+
+    public void registerDriverWithShuffleService(
+            String host,
+            int port,
+            long heartbeatTimeoutMs,
+            long heartbeatIntervalMs) throws IOException, InterruptedException {
+        checkInit();
+        ByteBuffer registerDriver = new RegisterDriver(appId, heartbeatTimeoutMs).toByteBuffer();
+        TransportClient client = clientFactory.createClient(host, port);
+        client.sendRpc(registerDriver, new RegisterDriverCallback(client, heartbeatIntervalMs));
+    }
+
+    @Override
+    public void close() {
+        heartbeaterThread.shutdownNow();
+        super.close();
+    }
+
+    private class RegisterDriverCallback implements RpcResponseCallback {
+        private final TransportClient client;
+        private final long heartbeatIntervalMs;
+
+        private RegisterDriverCallback(TransportClient client, long heartbeatIntervalMs) {
+            this.client = client;
+            this.heartbeatIntervalMs = heartbeatIntervalMs;
+        }
+
+        @Override
+        public void onSuccess(ByteBuffer response) {
+            heartbeaterThread.scheduleAtFixedRate(
+                    new Heartbeater(client), 0, heartbeatIntervalMs, TimeUnit.MILLISECONDS);
+            logger.info("Successfully registered app " + appId + " with external shuffle service.");
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            logger.warn("Unable to register app " + appId + " with external shuffle service. " +
+                    "Please manually remove shuffle data after driver exit. Error: " + e);
+        }
+    }
+
+    private class Heartbeater implements Runnable {
+
+        private final TransportClient client;
+
+        private Heartbeater(TransportClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            // TODO: Stop sending heartbeats if the shuffle service has lost the app due to timeout
+            client.send(new ShuffleServiceHeartbeat(appId).toByteBuffer());
+        }
+    }
+}

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -254,8 +254,14 @@ private[spark] class BlockManager(
     blockManagerId = if (idFromMaster != null) idFromMaster else id
 
     shuffleServerId = if (externalShuffleServiceEnabled) {
-      logInfo(s"external shuffle service port = $externalShuffleServicePort")
-      BlockManagerId(executorId, blockTransferService.hostName, externalShuffleServicePort)
+      val shuffleServerHostName = if (blockManagerId.isDriver) {
+        blockTransferService.hostName
+      } else {
+        conf.get("spark.shuffle.service.host", blockTransferService.hostName)
+      }
+      logInfo(s"external shuffle service host = $shuffleServerHostName, " +
+        s"port = $externalShuffleServicePort")
+      BlockManagerId(executorId, shuffleServerHostName, externalShuffleServicePort)
     } else {
       blockManagerId
     }

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -173,6 +173,40 @@ exits.
 
 Use the exact prefix `spark.kubernetes.authenticate` for Kubernetes authentication parameters in client mode.
 
+## Dynamic Executor Scaling
+
+To enable dynamic resource allocation, you need to first launch our external shuffle service on the nodes that spark executors will
+be created on. This is typically a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) with a provisioned
+[hostpath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume. This shuffle service may be shared by executors
+belonging to different SparkJobs. Using Spark with dynamic allocation on Kubernetes assumes that a cluster administrator has set up one
+or more shuffle-service DaemonSets in the cluster.
+
+A sample configuration file is provided in `conf\k8s-shuffle-service.yaml.template` which can be customized as needed for a particular cluster.
+It is important to note that `spec.template.metadata.labels` are setup appropriately for the shuffle service because there may be multiple
+shuffle service instances running in a cluster. The labels give Spark applications a way to target a particular shuffle service.
+
+Please note that when enabling dynamic resource allocation, the executor's shuffle files should be visible to the shuffle service that
+located on the same node, which means the volume mount configuration of shuffle service should be identical to spark executors'.
+
+For example, if the shuffle service we want to use is in the 'spark' namespace, and has pods with labels app=spark-shuffle-service, we can use
+those tags to target that particular shuffle service at job launch time. In order to run a job with dynamic allocation enabled,
+the command may then look like the following:
+
+```bash
+$ bin/spark-submit \
+    --master k8s://https://<k8s-apiserver-host>:<k8s-apiserver-port> \
+    --deploy-mode cluster \
+    --name spark-groupby \
+    --class org.apache.spark.examples.GroupByTest \
+    --conf spark.local.dir=/tmp/spark-local \
+    --conf spark.dynamicAllocation.enabled=true \
+    --conf spark.shuffle.service.enabled=true \
+    --conf spark.kubernetes.shuffle.namespace=spark \
+    --conf spark.kubernetes.shuffle.labels="app=spark-shuffle-service" \
+    --conf spark.kubernetes.container.image=<spark-image> \
+    local:///path/to/examples.jar 10 400000 2
+```
+
 ## Dependency Management
 
 If your application's dependencies are all hosted in remote locations like HDFS or HTTP servers, they may be referred to

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -30,6 +30,30 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault("default")
 
+  val KUBERNETES_SHUFFLE_NAMESPACE =
+    ConfigBuilder("spark.kubernetes.shuffle.namespace")
+      .doc("Namespace of the shuffle service")
+      .stringConf
+      .createWithDefault("default")
+
+  val KUBERNETES_SHUFFLE_LABELS =
+    ConfigBuilder("spark.kubernetes.shuffle.labels")
+      .doc("Labels to identify the shuffle service")
+      .stringConf
+      .createOptional
+
+  val SPARK_SHUFFLE_SERVICE_HOST =
+    ConfigBuilder("spark.shuffle.service.host")
+      .doc("Host for Spark Shuffle Service")
+      .internal()
+      .stringConf
+      .createOptional
+
+  val SHUFFLE_CLEANER_INTERVAL_S =
+    ConfigBuilder("spark.shuffle.cleaner.interval")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("30s")
+
   val CONTAINER_IMAGE =
     ConfigBuilder("spark.kubernetes.container.image")
       .doc("Container image to use for Spark containers. Individual container types " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -16,10 +16,43 @@
  */
 package org.apache.spark.deploy.k8s
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.util.Utils
 
 private[spark] object KubernetesUtils {
+
+  def parseKeyValuePairs(
+      maybeKeyValues: Option[String],
+      configKey: String,
+      keyValueType: String): Map[String, String] = {
+
+    maybeKeyValues.map(keyValues => {
+      keyValues.split(",").map(_.trim).filterNot(_.isEmpty).map(keyValue => {
+        keyValue.split("=", 2).toSeq match {
+          case Seq(k, v) =>
+            (k, v)
+          case _ =>
+            throw new SparkException(s"Custom $keyValueType set by $configKey must be a" +
+              s" comma-separated list of key-value pairs, with format <key>=<value>." +
+              s" Got value: $keyValue. All values: $keyValues")
+        }
+      }).toMap
+    }).getOrElse(Map.empty[String, String])
+  }
+
+  def parsePrefixedKeyValuePairs(
+      sparkConf: SparkConf,
+      prefix: String,
+      configType: String): Map[String, String] = {
+    val fromPrefix = sparkConf.getAllWithPrefix(prefix)
+    fromPrefix.groupBy(_._1).foreach {
+      case (key, values) =>
+        require(values.size == 1,
+          s"Cannot have multiple values for a given $configType key, got key $key with" +
+            s" values $values")
+    }
+    fromPrefix.toMap
+  }
 
   /**
    * Extract and parse Spark configuration properties with a given name prefix and

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExternalShuffleLocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/ExternalShuffleLocalDirsFeatureStep.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import io.fabric8.kubernetes.api.model.{Volume, VolumeBuilder, VolumeMount, VolumeMountBuilder}
+import org.apache.commons.io.FilenameUtils
+
+import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesRoleSpecificConf}
+import org.apache.spark.util.Utils
+
+class ExternalShuffleLocalDirsFeatureStep(
+    conf: KubernetesConf[_ <: KubernetesRoleSpecificConf]) extends LocalDirsFeatureStep(conf) {
+
+  private val resolvedLocalDirs = Utils.getConfiguredLocalDirs(conf.sparkConf)
+
+  override def getDirVolumesWithMounts(): Seq[(Volume, VolumeMount)] = {
+    // TODO: Using hostPath for the local directory will also make it such that the
+    // other uses of the local directory - broadcasting and caching - will also write
+    // to the directory that the shuffle service is aware of. It would be better for
+    // these directories to be separate so that the lifetime of the non-shuffle scratch
+    // space is tied to an emptyDir instead of the hostPath. This requires a change in
+    // core Spark as well.
+    resolvedLocalDirs.zipWithIndex.map {
+      case (shuffleDir, shuffleDirIndex) =>
+        val volumeName = s"$shuffleDirIndex-${FilenameUtils.getBaseName(shuffleDir)}"
+        val volume = new VolumeBuilder()
+          .withName(volumeName)
+          .withNewHostPath(shuffleDir, "")
+          .build()
+        val volumeMount = new VolumeMountBuilder()
+          .withName(volumeName)
+          .withMountPath(shuffleDir)
+          .build()
+        (volume, volumeMount)
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -16,10 +16,9 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import java.nio.file.Paths
 import java.util.UUID
 
-import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, VolumeBuilder, VolumeMountBuilder}
+import io.fabric8.kubernetes.api.model._
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverSpecificConf, KubernetesRoleSpecificConf, SparkPod}
 
@@ -38,10 +37,10 @@ private[spark] class LocalDirsFeatureStep(
     .getOrElse(defaultLocalDir)
     .split(",")
 
-  override def configurePod(pod: SparkPod): SparkPod = {
+  def getDirVolumesWithMounts(): Seq[(Volume, VolumeMount)] = {
     val localDirVolumes = resolvedLocalDirs
       .zipWithIndex
-      .map { case (localDir, index) =>
+      .map { case (_, index) =>
         new VolumeBuilder()
           .withName(s"spark-local-dir-${index + 1}")
           .withNewEmptyDir()
@@ -56,9 +55,14 @@ private[spark] class LocalDirsFeatureStep(
           .withMountPath(localDirPath)
           .build()
       }
+    localDirVolumes.zip(localDirVolumeMounts)
+  }
+
+  override def configurePod(pod: SparkPod): SparkPod = {
+    val volumesWithMounts = getDirVolumesWithMounts()
     val podWithLocalDirVolumes = new PodBuilder(pod.pod)
       .editSpec()
-        .addToVolumes(localDirVolumes: _*)
+        .addToVolumes(volumesWithMounts.map(_._1): _*)
         .endSpec()
       .build()
     val containerWithLocalDirVolumeMounts = new ContainerBuilder(pod.container)
@@ -66,7 +70,7 @@ private[spark] class LocalDirsFeatureStep(
         .withName("SPARK_LOCAL_DIRS")
         .withValue(resolvedLocalDirs.mkString(","))
         .endEnv()
-      .addToVolumeMounts(localDirVolumeMounts: _*)
+      .addToVolumeMounts(volumesWithMounts.map(_._2): _*)
       .build()
     SparkPod(podWithLocalDirVolumes, containerWithLocalDirVolumeMounts)
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -23,10 +23,13 @@ import com.google.common.cache.CacheBuilder
 import io.fabric8.kubernetes.client.Config
 
 import org.apache.spark.SparkContext
-import org.apache.spark.deploy.k8s.{KubernetesUtils, SparkKubernetesClientFactory}
+import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesRoleSpecificConf, KubernetesUtils, SparkKubernetesClientFactory}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.internal.Logging
+import org.apache.spark.deploy.k8s.features.{ExternalShuffleLocalDirsFeatureStep, LocalDirsFeatureStep}
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.network.netty.SparkTransportConf
+import org.apache.spark.network.shuffle.kubernetes.KubernetesExternalShuffleClient
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
 import org.apache.spark.util.{SystemClock, ThreadUtils}
 
@@ -79,15 +82,38 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     val removedExecutorsCache = CacheBuilder.newBuilder()
       .expireAfterWrite(3, TimeUnit.MINUTES)
       .build[java.lang.Long, java.lang.Long]()
+
+    val kubernetesShuffleManager = if (sc.conf.get(
+      org.apache.spark.internal.config.SHUFFLE_SERVICE_ENABLED)) {
+      val kubernetesExternalShuffleClient = new KubernetesExternalShuffleClient(
+        SparkTransportConf.fromSparkConf(sc.conf, "shuffle"),
+        sc.env.securityManager,
+        sc.env.securityManager.isAuthenticationEnabled(),
+        sc.conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
+      Some(new KubernetesExternalShuffleManagerImpl(
+        sc.conf,
+        kubernetesClient,
+        kubernetesExternalShuffleClient))
+    } else None
+
+    val localDirsFeatureStepFactory: KubernetesConf[_ <: KubernetesRoleSpecificConf]
+      => LocalDirsFeatureStep = if (kubernetesShuffleManager.isDefined) {
+      new ExternalShuffleLocalDirsFeatureStep(_)
+    } else {
+      new LocalDirsFeatureStep(_)
+    }
+
+    val kubernetesExecutorBuilder = new KubernetesExecutorBuilder(
+      provideLocalDirsStep = localDirsFeatureStepFactory)
     val executorPodsLifecycleEventHandler = new ExecutorPodsLifecycleManager(
       sc.conf,
-      new KubernetesExecutorBuilder(),
+      kubernetesExecutorBuilder,
       kubernetesClient,
       snapshotsStore,
       removedExecutorsCache)
 
     val executorPodsAllocator = new ExecutorPodsAllocator(
-      sc.conf, new KubernetesExecutorBuilder(), kubernetesClient, snapshotsStore, new SystemClock())
+      sc.conf, kubernetesExecutorBuilder, kubernetesClient, snapshotsStore, new SystemClock())
 
     val podsWatchEventSource = new ExecutorPodsWatchSnapshotSource(
       snapshotsStore,
@@ -107,7 +133,8 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       executorPodsAllocator,
       executorPodsLifecycleEventHandler,
       podsWatchEventSource,
-      podsPollingEventSource)
+      podsPollingEventSource,
+      kubernetesShuffleManager)
   }
 
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExternalShuffleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExternalShuffleManager.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientException, Watch, Watcher}
+import io.fabric8.kubernetes.client.Watcher.Action
+import io.fabric8.kubernetes.client.internal.readiness.Readiness
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.KubernetesUtils
+import org.apache.spark.internal.Logging
+import org.apache.spark.network.shuffle.kubernetes.KubernetesExternalShuffleClient
+
+private[spark] trait KubernetesExternalShuffleManager {
+  def start(appId: String): Unit
+
+  def stop(): Unit
+
+  /**
+   * Returns the properties that should be applied for this executor pod, given that
+   * this executor will need to communicate with an external shuffle service.
+   *
+   * In practice, this seq will always have a size of 1, but since this method's semantics are that
+   * the returned values are key-value pairs to apply as properties, it is clearer to express
+   * this as a collection.
+   */
+  def getShuffleServiceConfigurationForExecutor(executorPod: Pod): Seq[(String, String)]
+}
+
+private[spark] class KubernetesExternalShuffleManagerImpl(
+                                                           sparkConf: SparkConf,
+                                                           client: KubernetesClient,
+                                                           shuffleClient: KubernetesExternalShuffleClient)
+  extends KubernetesExternalShuffleManager with Logging {
+
+  private val shuffleNamespace = sparkConf.get(KUBERNETES_SHUFFLE_NAMESPACE)
+  private val shufflePodLabels = KubernetesUtils.parseKeyValuePairs(
+    sparkConf.get(KUBERNETES_SHUFFLE_LABELS),
+    KUBERNETES_SHUFFLE_LABELS.key,
+    "shuffle-labels")
+  if (shufflePodLabels.isEmpty) {
+    throw new SparkException(s"Dynamic allocation enabled " +
+      s"but no ${KUBERNETES_SHUFFLE_LABELS.key} specified")
+  }
+  private val externalShufflePort = sparkConf.getInt("spark.shuffle.service.port", 7337)
+  private val shufflePodCache = scala.collection.mutable.Map[String, String]()
+  private var watcher: Watch = _
+
+  override def start(appId: String): Unit = {
+    // seed the initial cache.
+    val pods = client.pods()
+      .inNamespace(shuffleNamespace)
+      .withLabels(shufflePodLabels.asJava)
+      .list()
+    pods.getItems.asScala.foreach {
+      pod =>
+        if (Readiness.isReady(pod)) {
+          addShufflePodToCache(pod)
+        } else {
+          logWarning(s"Found unready shuffle pod ${pod.getMetadata.getName} " +
+            s"on node ${pod.getSpec.getNodeName}")
+        }
+    }
+
+    watcher = client
+      .pods()
+      .inNamespace(shuffleNamespace)
+      .withLabels(shufflePodLabels.asJava)
+      .watch(new Watcher[Pod] {
+        override def eventReceived(action: Watcher.Action, p: Pod): Unit = {
+          action match {
+            case Action.DELETED | Action.ERROR =>
+              shufflePodCache.remove(p.getSpec.getNodeName)
+            case Action.ADDED | Action.MODIFIED if Readiness.isReady(p) =>
+              addShufflePodToCache(p)
+          }
+        }
+        override def onClose(e: KubernetesClientException): Unit = {}
+      })
+    shuffleClient.init(appId)
+  }
+
+  private def addShufflePodToCache(pod: Pod): Unit = shufflePodCache.synchronized {
+    if (shufflePodCache.contains(pod.getSpec.getNodeName)) {
+      val registeredPodName = shufflePodCache(pod.getSpec.getNodeName)
+      if (registeredPodName.equals(pod.getStatus.getPodIP)) {
+        logWarning(s"The same pod $registeredPodName is added again on ${pod.getSpec.getNodeName}")
+      } else {
+        throw new SparkException(s"Ambiguous specification of shuffle service pod. " +
+          s"Found multiple matching pods: ${pod.getMetadata.getName}, " +
+          s"$registeredPodName on ${pod.getSpec.getNodeName}")
+      }
+    } else {
+      shufflePodCache(pod.getSpec.getNodeName) = pod.getStatus.getPodIP
+    }
+  }
+
+  override def stop(): Unit = {
+    watcher.close()
+    shuffleClient.close()
+  }
+
+  override def getShuffleServiceConfigurationForExecutor(executorPod: Pod)
+  : Seq[(String, String)] = {
+    val nodeName = executorPod.getSpec.getNodeName
+    val shufflePodIp = shufflePodCache.synchronized {
+      shufflePodCache.getOrElse(nodeName,
+        throw new SparkException(s"Unable to find shuffle pod on node $nodeName"))
+    }
+    // Inform the shuffle pod about this application so it can watch.
+    shuffleClient.registerDriverWithShuffleService(
+      shufflePodIp,
+      externalShufflePort,
+      sparkConf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+        s"${sparkConf.getTimeAsSeconds("spark.network.timeout", "120s")}s"),
+      sparkConf.getTimeAsMs("spark.executor.heartbeatInterval", "10s")
+    )
+    Seq((SPARK_SHUFFLE_SERVICE_HOST.key, shufflePodIp))
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -98,7 +98,8 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
       podAllocator,
       lifecycleEventHandler,
       watchEvents,
-      pollEvents)
+      pollEvents,
+      None)
   }
 
   test("Start all components") {


### PR DESCRIPTION

### What changes were proposed in this pull request?
-  External shuffle service works as a DaemonSet.
-  Shuffle service pod and executor pod share with the same localdir on the same host.
-  SchedulerBackend maintains a cache of shuffle service pod and serve for executor to find the shuffle service on the same host.
-  Add a KubernetesExternalShuffleClient for for talking to the external shuffle service in Kubernetes cluster mode in order to cleanup shuffle data for driver death.

### Why are the changes needed?
The kubernetes external shuffle service is added to allow Spark to use Dynamic Allocation Mode when running in Kubernetes. The shuffle service is responsible for persisting shuffle files beyond the lifetime of the executors, allowing the number of executors to scale up and down without losing computation.
